### PR TITLE
Update installation instructions in mac.md

### DIFF
--- a/docs/mac.md
+++ b/docs/mac.md
@@ -105,7 +105,7 @@ brew install argocd
 brew install netbirdio/tap/netbird
 brew install --cask netbirdio/tap/netbird-ui
 brew install pi-coding-agent
-brew install --cask warp
+brew install --cask iterm2
 ```
 
 ## Some easy fix


### PR DESCRIPTION
Replaced the installation of 'warp' with 'iterm2' in the mac.md documentation.