### PR TITLE
Remove xclip from documentation

### DIFF
--- a/docs/mac.md
+++ b/docs/mac.md
@@ -82,7 +82,6 @@ Here is the list of packages I usually use:
 - [iTerm2](https://github.com/gnachman/iterm2)
 - [GitUI](https://github.com/gitui-org/gitui)
 - [bat](https://github.com/sharkdp/bat)
-- [xclip](https://github.com/astrand/xclip)
 - [gh](https://cli.github.com/)
 
 ### Install Packages
@@ -116,7 +115,6 @@ brew install pi-coding-agent
 brew install --cask iterm2
 brew install gitui
 brew install bat
-brew install xclip
 brew install gh
 ```
 


### PR DESCRIPTION
Removed xclip from the list of recommended packages and installation commands.