### PR TITLE
Allow 'sleep' command in bash permissions

### DIFF
--- a/docs/pi.md
+++ b/docs/pi.md
@@ -246,6 +246,7 @@ File to modify: `~/.pi/agent/extensions/pi-permission-system/config.json`:
     "steer_subagent": "allow",
     "bash": {
       "npm ls *": "allow",
+      "sleep *": "allow",
       "base64 *": "allow",
       "gh run *": "allow",
       "while *": "allow",


### PR DESCRIPTION
Add permission for the 'sleep' command in bash.