### PR TITLE
Remove Hunk and diffnav from mac.md

### DIFF
--- a/docs/mac.md
+++ b/docs/mac.md
@@ -82,8 +82,6 @@ Here is the list of packages I usually use:
 - [iTerm2](https://github.com/gnachman/iterm2)
 - [herdr](https://herdr.dev/)
 - [GitUI](https://github.com/gitui-org/gitui)
-- [Hunk](https://github.com/modem-dev/hunk)
-- [diffnav](https://github.com/dlvhdr/diffnav)
 - [bat](https://github.com/sharkdp/bat)
 - [gh](https://cli.github.com/)
 - [lychee](https://lychee.cli.rs/)
@@ -120,9 +118,6 @@ brew install --cask iterm2
 brew install herdr
 herdr integration install pi
 brew install gitui
-brew install modem-dev/tap/hunk
-brew install dlvhdr/formulae/diffnav
-git config --global pager.diff diffnav
 brew install bat
 brew install gh
 brew install lychee


### PR DESCRIPTION
Removed Hunk and diffnav from the list of tools and installation commands.